### PR TITLE
Remove contributors condition

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -6,12 +6,6 @@ policy:
 
 approval_rules:
   - name: reviewers have approved
-    if:
-      # "author_is_only_contributor", when true, is satisfied if all commits in the
-      # pull request are authored by and committed by the user who opened the pull
-      # request. When false, it is satisfied if at least one commit in the pull
-      # request was authored or committed by another user.
-      author_is_only_contributor: false
 
     requires:
       # "count" is the number of required approvals. The default is 0, meaning no


### PR DESCRIPTION
We want to allow multiple contributors, without requiring it.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>