### PR TITLE
policies: approval: s/Signed-off-by/Acked-by

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -43,7 +43,7 @@ approval_rules:
         #
         # Note: Double-quote strings must escape backslashes while single/plain do not.
         comment_patterns:
-          - "^(?i)signed(-| )off(-| )by:?\\s+" # eg. Signed-off-by: , signed off by
+          - "^(?i)acked(-| )by:?\\s+" # eg. Acked-by: , acked by
           - "^(?i)(@balena-ci\\s+)?i self-certify!?$" # eg. @balena-ci I self-certify!, i self-certify
           - "^(?i)(@balena-ci\\s+)?approve this please!?$" # eg. @balena-ci Approve this please!, approve this please
           - "^(?i)lgtm!?$" # eg. LGTM, lgtm, Lgtm


### PR DESCRIPTION
Acked-by is a more appropriate approval comment than Signed-off-by, the latter of which is used to indicate that the contribution complies with the licensing of the project, rather than indicating that the contribution has been reviewed and found to have technical merit.

https://www.kernel.org/doc/html/v4.17/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>