### PR TITLE
Approve renovate PRs automatically

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -2,7 +2,7 @@ policy:
   approval:
     - or:
         - reviewers have approved
-        # - pull request has the no-review label
+        - pull request has special labels
 
 approval_rules:
   - name: reviewers have approved
@@ -52,21 +52,11 @@ approval_rules:
         # will be accepted as approval candidates. Default is true.
         github_review: true
 
-  # TODO: check who has permissions to add labels before enabling
-  - name: pull request has the no-review label
+  - name: pull request has special labels
     if:
-      # "author_is_only_contributor", when true, is satisfied if all commits in the
-      # pull request are authored by and committed by the user who opened the pull
-      # request. When false, it is satisfied if at least one commit in the pull
-      # request was authored or committed by another user.
-      author_is_only_contributor: false
-
       # "has_labels" is satisfied if the pull request has the specified labels
       # applied
       has_labels:
+        - "renovate"
+        - "dependencies"
         - "no-review"
-
-    requires:
-      # "count" is the number of required approvals. The default is 0, meaning no
-      # approval is necessary.
-      count: 0 # indicates "auto-approval"


### PR DESCRIPTION
* simplify renovate-config(s)
* [renovate](https://github.com/product-os/renovate-config/blob/master/.github/renovate.json#L21-L23) adds `renovate` and `dependencies` labels to each PR
* write privilege required to label PRs

Change-type: minor