### PR TITLE
Invalidate approvals on push for forks only

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -2,12 +2,23 @@ policy:
   approval:
     - or:
         - reviewers have approved
+        - reviewers have approved fork
         - has renovate minor labels
         - has renovate patch labels
         - has renovate digest labels
         - has label no-review
 approval_rules:
   - name: reviewers have approved
+
+    if:
+      # "from_branch" is satisfied if the source branch of the pull request
+      # matches the regular expression. Note that source branches from forks will
+      # have the pattern "repo_owner:branch_name"
+      #
+      # Note: Double-quote strings must escape backslashes while single/plain do not.
+      # See the Notes on YAML Syntax section of this README for more information.
+      from_branch:
+        pattern: "^[^:]+$"
 
     requires:
       # "count" is the number of required approvals. The default is 0, meaning no
@@ -29,6 +40,54 @@ approval_rules:
       # a contributor. If allow_author and allow_contributor would disagree, this option
       # always wins. False by default.
       allow_contributor: true
+
+      # If true, pushing new commits to a pull request will invalidate existing
+      # approvals for this rule. False by default.
+      invalidate_on_push: false
+
+      methods:
+        # If a comment contains a string in this list, it counts as approval. Use
+        # the "comment_patterns" option if you want to match full comments. The
+        # default values are shown.
+        comments: []
+
+        # If a comment matches a regular expression in this list, it counts as
+        # approval. Defaults to an empty list.
+        #
+        # Note: Double-quote strings must escape backslashes while single/plain do not.
+        comment_patterns:
+          - "^(?i)acked(-| )by:?\\s+" # eg. Acked-by: , acked by
+          - "^(?i)(@balena-ci\\s+)?i self-certify!?$" # eg. @balena-ci I self-certify!, i self-certify
+          - "^(?i)(@balena-ci\\s+)?approve this please!?$" # eg. @balena-ci Approve this please!, approve this please
+          - "^(?i)lgtm!?$" # eg. LGTM, lgtm, Lgtm
+
+        # If true, GitHub reviews can be used for approval. All GitHub review approvals
+        # will be accepted as approval candidates. Default is true.
+        github_review: true
+
+  - name: reviewers have approved fork
+
+    if:
+      # "from_branch" is satisfied if the source branch of the pull request
+      # matches the regular expression. Note that source branches from forks will
+      # have the pattern "repo_owner:branch_name"
+      #
+      # Note: Double-quote strings must escape backslashes while single/plain do not.
+      # See the Notes on YAML Syntax section of this README for more information.
+      from_branch:
+        pattern: "^.+:.+$"
+
+    requires:
+      # "count" is the number of required approvals. The default is 0, meaning no
+      # approval is necessary.
+      count: 1
+
+      # A user must have at least the minimum permission in this list for their
+      # approval to count for this rule. Valid permissions are "admin", "maintain",
+      # "write", "triage", and "read".
+      permissions: ["write"]
+
+    options:
 
       # If true, pushing new commits to a pull request will invalidate existing
       # approvals for this rule. False by default.


### PR DESCRIPTION
Internal branches should only need to be approved once.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>