### PR TITLE
Revert "Do not match renovate labels on balena-os repos for now"

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -155,9 +155,6 @@ approval_rules:
         - "renovate"
         - "dependencies"
         - "minor"
-      repository:
-        not_matches:
-          - "balena-os/.+"
 
   - name: has renovate patch labels
     if:
@@ -165,9 +162,6 @@ approval_rules:
         - "renovate"
         - "dependencies"
         - "patch"
-      repository:
-        not_matches:
-          - "balena-os/.+"
 
   # legacy?
   - name: has renovate digest labels
@@ -176,9 +170,6 @@ approval_rules:
         - "renovate"
         - "dependencies"
         - "digest"
-      repository:
-        not_matches:
-          - "balena-os/.+"
 
   - name: has renovate pinDigest labels
     if:
@@ -186,9 +177,6 @@ approval_rules:
         - "renovate"
         - "dependencies"
         - "pinDigest"
-      repository:
-        not_matches:
-          - "balena-os/.+"
 
   - name: has label no-review
     if:


### PR DESCRIPTION
This reverts commit 8a6150414d4825d97267769852e3d7a3229a5739.

Change-type: patch