### PR TITLE
Require sudoer approval for some repositories

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -1,92 +1,67 @@
 policy:
   approval:
     - or:
-        - reviewers have approved
-        - reviewers have approved fork
+        - sudoers have approved
+        - members have approved
+        - members have approved fork
         - has renovate minor labels
         - has renovate patch labels
         - has renovate digest labels
         - has renovate pinDigest labels
+        - has renovate pin labels
         - has label no-review
 
 approval_rules:
-  - name: reviewers have approved
+  # some repositories require sudoers approval
+  - name: sudoers have approved
 
     if:
-      # "from_branch" is satisfied if the source branch of the pull request
-      # matches the regular expression. Note that source branches from forks will
-      # have the pattern "repo_owner:branch_name"
-      #
-      # Note: Double-quote strings must escape backslashes while single/plain do not.
-      # See the Notes on YAML Syntax section of this README for more information.
+      # exclude forks from this rule
       from_branch:
         pattern: "^[^:]+$"
+      # include the following repositories that require sudoers approval
+      repository:
+        matches:
+          - "product-os/policies"
+          - "balenaltd/admins"
+          - ".*/.github"
 
     requires:
-      # "count" is the number of required approvals. The default is 0, meaning no
-      # approval is necessary.
       count: 1
+      teams:
+        - "balenaltd/sudoers"
 
-      # A user must have at least the minimum permission in this list for their
-      # approval to count for this rule. Valid permissions are "admin", "maintain",
-      # "write", "triage", and "read".
-      permissions: ["write"]
-
-    options:
-      # If true, approvals by the author of a pull request are considered when
-      # calculating the status. False by default.
+    options: &options
       allow_author: true
-
-      # If true, the approvals of someone who has committed to the pull request are
-      # considered when calculating the status. The pull request author is considered
-      # a contributor. If allow_author and allow_contributor would disagree, this option
-      # always wins. False by default.
       allow_contributor: true
-
-      # If true, pushing new commits to a pull request will invalidate existing
-      # approvals for this rule. False by default.
       invalidate_on_push: false
 
       methods:
-        # If a comment contains a string in this list, it counts as approval. Use
-        # the "comment_patterns" option if you want to match full comments. The
-        # default values are shown.
         comments: []
-
-        # If a comment matches a regular expression in this list, it counts as
-        # approval. Defaults to an empty list.
-        #
-        # Note: Double-quote strings must escape backslashes while single/plain do not.
         comment_patterns:
           - "^(?i)acked(-| )by:?\\s+" # eg. Acked-by: , acked by
           - "^(?i)(@balena-ci\\s+)?i self-certify!?$" # eg. @balena-ci I self-certify!, i self-certify
           - "^(?i)(@balena-ci\\s+)?approve this please!?$" # eg. @balena-ci Approve this please!, approve this please
           - "^(?i)lgtm!?$" # eg. LGTM, lgtm, Lgtm
-
-        # If true, GitHub reviews can be used for approval. All GitHub review approvals
-        # will be accepted as approval candidates. Default is true.
         github_review: true
 
-  - name: reviewers have approved fork
+  # remaining repositories can be approved by any team member
+  - name: members have approved
 
     if:
-      # "from_branch" is satisfied if the source branch of the pull request
-      # matches the regular expression. Note that source branches from forks will
-      # have the pattern "repo_owner:branch_name"
-      #
-      # Note: Double-quote strings must escape backslashes while single/plain do not.
-      # See the Notes on YAML Syntax section of this README for more information.
+      # exclude forks from this rule
       from_branch:
-        pattern: "^.+:.+$"
+        pattern: "^[^:]+$"
+      # exclude the following repositories that require sudoers approval
+      repository:
+        not_matches:
+          - "product-os/policies"
+          - "balenaltd/admins"
+          - ".*/.github"
 
-    requires:
-      # "count" is the number of required approvals. The default is 0, meaning no
-      # approval is necessary.
+    requires: &requireMembers
       count: 1
-
-      # A user must be in the list of users or belong to at least one of the given
-      # organizations or teams for their approval to count for this rule.
-      # users: ["user1", "user2"]
+      permissions: ["write"]
       organizations:
         - "balena-fleetops"
         - "balena-io"
@@ -125,32 +100,40 @@ approval_rules:
         - "product-os/balena-dev"
 
     options:
+      <<: *options
 
-      # If true, approvals by the author of a pull request are considered when
-      # calculating the status. False by default.
+  # allow forks but disallow comments and invalidate on push
+  - name: members have approved fork
+
+    if:
+      # include forks in this rule
+      from_branch:
+        pattern: "^.+:.+$"
+      # exclude the following repositories that require sudoers approval
+      repository:
+        not_matches:
+          - "product-os/policies"
+          - "balenaltd/admins"
+          - ".*/.github"
+
+    requires:
+      <<: *requireMembers
+
+    options:
       allow_author: true
-
-      # If true, the approvals of someone who has committed to the pull request are
-      # considered when calculating the status. The pull request author is considered
-      # a contributor. If allow_author and allow_contributor would disagree, this option
-      # always wins. False by default.
       allow_contributor: true
-
-      # If true, pushing new commits to a pull request will invalidate existing
-      # approvals for this rule. False by default.
+      # invalidate on push for forks
       invalidate_on_push: true
 
       methods:
-        # Do not allow approvals by comments in order to avoid author spoofing
+        # disable comment approvals
         comments: []
-
-        # If true, GitHub reviews can be used for approval. All GitHub review approvals
-        # will be accepted as approval candidates. Default is true.
+        comment_patterns: []
+        # allow github review approvals
         github_review: true
 
   - name: has renovate minor labels
     if:
-      # "has_labels" is satisfied if the pull request has the specified labels
       has_labels:
         - "renovate"
         - "dependencies"
@@ -163,7 +146,6 @@ approval_rules:
         - "dependencies"
         - "patch"
 
-  # legacy?
   - name: has renovate digest labels
     if:
       has_labels:
@@ -177,6 +159,13 @@ approval_rules:
         - "renovate"
         - "dependencies"
         - "pinDigest"
+
+  - name: has renovate pin labels
+    if:
+      has_labels:
+        - "renovate"
+        - "dependencies"
+        - "pin"
 
   - name: has label no-review
     if:


### PR DESCRIPTION
Also use yaml anchors to avoid duplication.

Change-type: minor