### PR TITLE
Remove custom renovate label policies

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -4,11 +4,6 @@ policy:
         - reviewers have approved internal contributions
         - reviewers have approved with invalidate on push
         - auto-approved via no-review label
-        - auto-approved via minor label
-        - auto-approved via patch label
-        - auto-approved via digest label
-        - auto-approved via pinDigest label
-        - auto-approved via pin label
   disapproval:
     requires:
       permissions: ["write"]
@@ -84,32 +79,3 @@ approval_rules:
           - "balena-io/renovate-config"
           - "balena-os/renovate-config"
           - "product-os/renovate-config"
-
-  - name: auto-approved via minor label
-    if: &renovateConditions
-      has_labels: ["minor"]
-      has_author_in:
-        users: ["balena-renovate[bot]"]
-      repository:
-        not_matches: *adminRepositories
-      author_is_only_contributor: true
-
-  - name: auto-approved via patch label
-    if:
-      <<: *renovateConditions
-      has_labels: ["patch"]
-
-  - name: auto-approved via digest label
-    if:
-      <<: *renovateConditions
-      has_labels: ["digest"]
-
-  - name: auto-approved via pinDigest label
-    if:
-      <<: *renovateConditions
-      has_labels: ["pinDigest"]
-
-  - name: auto-approved via pin label
-    if:
-      <<: *renovateConditions
-      has_labels: ["pin"]


### PR DESCRIPTION
Renovate has now been configured to use the no-review label

Change-type: patch