### PR TITLE
Re-enable invalidate on push for external contributions

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -60,8 +60,7 @@ approval_rules:
     options:
       allow_author: true
       allow_contributor: true
-      # FIXME: set true after https://github.com/palantir/policy-bot/pull/602 merges
-      invalidate_on_push: false
+      invalidate_on_push: true
       ignore_edited_comments: true
 
       methods:


### PR DESCRIPTION
See: https://github.com/palantir/policy-bot/pull/602
See: https://github.com/product-os/policy-bot/pull/4
See: https://github.com/product-os/environment-production/pull/623

Change-type: patch