### PR TITLE
Apply no-self-certify policy to balena-io

### DIFF
--- a/.github/balena-fleetops.yml
+++ b/.github/balena-fleetops.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-fleetops/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-examples.yml
+++ b/.github/balena-io-examples.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-examples/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-experimental.yml
+++ b/.github/balena-io-experimental.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-experimental/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-hardware.yml
+++ b/.github/balena-io-hardware.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-hardware/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-incubator.yml
+++ b/.github/balena-io-incubator.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-incubator/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-library.yml
+++ b/.github/balena-io-library.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-library/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-modules.yml
+++ b/.github/balena-io-modules.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-modules/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-projects.yml
+++ b/.github/balena-io-projects.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-projects/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io-security.yml
+++ b/.github/balena-io-security.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-io-security/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-io.yml
+++ b/.github/balena-io.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/repo-file-sync-action
 balena-io/.github:
-  - source: policies/approval.yml
+  - source: policies/no-self-certify.yml
     dest: policies/approval.yml
     deleteOrphaned: true

--- a/.github/balena-io.yml
+++ b/.github/balena-io.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/repo-file-sync-action
-$DESTINATION_REPO:
-  - source: policies/
-    dest: policies/
+balena-io/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
     deleteOrphaned: true

--- a/.github/balena-labs-projects.yml
+++ b/.github/balena-labs-projects.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-labs-projects/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-labs-research.yml
+++ b/.github/balena-labs-research.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-labs-research/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balena-os.yml
+++ b/.github/balena-os.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balena-os/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balenalabs-incubator.yml
+++ b/.github/balenalabs-incubator.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balenalabs-incubator/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balenalabs.yml
+++ b/.github/balenalabs.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balenalabs/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/balenaltd.yml
+++ b/.github/balenaltd.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+balenaltd/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/company-os.yml
+++ b/.github/company-os.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+company-os/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/people-os.yml
+++ b/.github/people-os.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+people-os/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/product-os-test.yml
+++ b/.github/product-os-test.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+product-os-test/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/product-os.yml
+++ b/.github/product-os.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/repo-file-sync-action
+product-os/.github:
+  - source: policies/approval.yml
+    dest: policies/approval.yml
+    deleteOrphaned: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -51,14 +51,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Update sync.yml
-        working-directory: .github
-        env:
-          DESTINATION_REPO: ${{ matrix.org }}/.github
-        run: |
-          envsubst < sync.yml.tmpl > sync.yml
-          cat sync.yml
-
       # https://github.com/marketplace/actions/repo-file-sync-action
       - name: Sync files
         uses: BetaHuhn/repo-file-sync-action@v1.21.0
@@ -70,3 +62,4 @@ jobs:
           COMMIT_EACH_FILE: false
           DRY_RUN: ${{ github.event_name == 'pull_request' }}
           COMMIT_BODY: "Change-type: patch"
+          CONFIG_PATH: .github/${{ matrix.org }}.yml

--- a/policies/no-self-certify.yml
+++ b/policies/no-self-certify.yml
@@ -19,8 +19,6 @@ policy:
           comments: []
           comment_patterns: &approvalCommentPatterns
             - "^(?i)acked(-| )by:?\\s+" # eg. Acked-by: , acked by
-            - "^(?i)(@balena-ci\\s+)?i self-certify!?$" # eg. @balena-ci I self-certify!, i self-certify
-            - "^(?i)(@balena-ci\\s+)?approve this please!?$" # eg. @balena-ci Approve this please!, approve this please
             - "^(?i)lgtm!?$" # eg. LGTM, lgtm, Lgtm!
           github_review: true
 
@@ -37,7 +35,7 @@ approval_rules:
       permissions: ["write"]
 
     options:
-      allow_author: true
+      allow_author: false
       allow_contributor: true
       invalidate_on_push: false
       ignore_edited_comments: true


### PR DESCRIPTION
By setting allow_author to false we are excluding
the author of the PR from any forms of approval.

Non-authors can still approve via the existing supported methods.

This is required to meet ISO and intentional work
guidelines for security compliance.

Change-type: patch
See: https://balena.fibery.io/Inputs/Research/Compliant-Github-PR-Management-456
See: https://balena.zulipchat.com/#narrow/stream/332163-_all/topic/Compliant.20and.20intentional.20PR.20Management