### PR TITLE
Allow contributions from multiple bots

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -95,4 +95,8 @@ approval_rules:
         not_matches:
           - "product-os/policies"
           - "balenaltd/admins"
-      author_is_only_contributor: true
+      only_has_contributors_in:
+        users:
+          - "balena-renovate[bot]"
+          - "flowzone-app[bot]"
+          - "github-actions[bot]"

--- a/policies/no-self-certify.yml
+++ b/policies/no-self-certify.yml
@@ -85,4 +85,8 @@ approval_rules:
         not_matches:
           - "product-os/policies"
           - "balenaltd/admins"
-      author_is_only_contributor: true
+      only_has_contributors_in:
+        users:
+          - "balena-renovate[bot]"
+          - "flowzone-app[bot]"
+          - "github-actions[bot]"


### PR DESCRIPTION
If multiple bots contribute to a PR it should
still pass the auto-approve conditions. As long
as a user isn't piggy-backing on the auto-approved changes.

Change-type: patch
See: https://github.com/balena-io/environment-production/pull/1907#issuecomment-1874370473