### PR TITLE
Allow bots to auto-approve PRs in environment-production

### DIFF
--- a/policies/approval.yml
+++ b/policies/approval.yml
@@ -110,7 +110,6 @@ approval_rules:
           - "product-os/policies"
           - "product-os/admins"
           - ".*/.github"
-          - "balena-io/environment-production"
           - "balena-io/environment-restricted"
       only_has_contributors_in:
         users:

--- a/policies/no-self-certify.yml
+++ b/policies/no-self-certify.yml
@@ -100,7 +100,6 @@ approval_rules:
           - "product-os/policies"
           - "product-os/admins"
           - ".*/.github"
-          - "balena-io/environment-production"
           - "balena-io/environment-restricted"
       only_has_contributors_in:
         users:


### PR DESCRIPTION
We use this so Renovate can conditionally automerge some packages, like UI, directly to prod so merge=deploy.

The automerge rules are in the [repo renovate config](https://github.com/balena-io/environment-production/blob/master/.github/renovate.json).

Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/2FA.20recovery.20keys.20not.20showing.20after.20confirming.20password/near/433292420